### PR TITLE
Fixed: OMS input reshowing on 'tab and enter' submit

### DIFF
--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -7,11 +7,13 @@
           <section v-if="showOmsInput">
             <ion-item lines="full">
               <ion-label position="fixed">{{ $t("OMS") }}</ion-label>
-              <ion-input name="instanceUrl" v-model="instanceUrl" id="instanceUrl"  type="text" required />
+              <ion-input name="instanceUrl" v-model="instanceUrl" id="instanceUrl" type="text" required />
             </ion-item>
 
             <div class="ion-padding">
-              <ion-button color="primary" expand="block" @click="setOms()">
+              <!-- @keyup.enter.stop to stop the form from submitting on enter press as keyup.enter is already bound
+              through the form above, causing both the form and the button to submit. -->
+              <ion-button color="primary" expand="block" @click.prevent="setOms()" @keyup.enter.stop>
                 {{ $t("Next") }}
                 <ion-icon slot="end" :icon="arrowForwardOutline" />
               </ion-button>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Providing OMS value and then navigating to the next button through the tab and pressing enter caused the OMS input to re-display on the UI. This was because of the programmatic behaviour of the form handler and the button handler colliding, causing both the handlers to be run at the same time, re-updating the condition which displays the OMS input on the UI.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)