### PR TITLE
Fixed: screen halt on logging by showing a loader until succesfully logged in (#81)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,6 +3,7 @@
   "Launch Pad": "Launch Pad",
   "Login": "Login",
   "Logout": "Logout",
+  "Logging in": "Loggin in",
   "Next": "Next",
   "OMS": "OMS",
   "Password": "Password",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,7 +3,7 @@
   "Launch Pad": "Launch Pad",
   "Login": "Login",
   "Logout": "Logout",
-  "Logging in": "Loggin in",
+  "Logging in": "Logging in",
   "Next": "Next",
   "OMS": "OMS",
   "Password": "Password",

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -236,6 +236,7 @@ export default defineComponent({
         return
       }
 
+      this.presentLoader('Logging in')
       try {
         await this.authStore.login(username.trim(), password)
         if (this.authStore.getRedirectUrl) {
@@ -249,6 +250,7 @@ export default defineComponent({
       } catch (error) {
         console.error(error)
       }
+      this.dismissLoader()
     },
     async samlLogin() {
       try {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Closes #81

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Added loader on login action to show till successful login.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
![Screenshot from 2024-02-21 12-39-33](https://github.com/hotwax/launchpad/assets/69574321/011807bb-e596-4786-b446-e10eb736b25b)



**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)