### PR TITLE
Implemented: support to not display login alert in any case and login into the app with the incoming credentials

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,4 @@
 {
-  "Already active session": "Already active session",
   "Failed to fetch user-profile, please try again": "Failed to fetch user-profile, please try again",
   "Launch Pad": "Launch Pad",
   "Login": "Login",
@@ -11,9 +10,7 @@
   "Please fill in the OMS": "Please fill in the OMS",
   "Please fill in the user details": "Please fill in the user details",
   "Processing": "Processing",
-  "Resume": "Resume",
   "Something went wrong while login. Please contact administrator.": "Something went wrong while login. Please contact administrator.",
   "Sorry, your username or password is incorrect. Please try again.": "Sorry, your username or password is incorrect. Please try again.",
-  "There is an already active session on for. Do you want to resume it, or would you prefer to log in again?": "There is an already active session on {oms} for {partyName}. Do you want to resume it, or would you prefer to log in again?",
   "Username": "Username"
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -43,7 +43,7 @@
               <ion-card-header class="app-content">
                 <ion-card-title color="text-medium">{{ app.name }}</ion-card-title>
                 <ion-buttons class="app-links">
-                  <ion-button color="medium" :href="scheme + app.handle + devHandle + domain + (authStore.isAuthenticated ? `/login?oms=${authStore.getOMS.startsWith('http') ? authStore.getOMS.includes('/api') ? authStore.getOMS : `${authStore.getOMS}/api/` : authStore.getOMS}&token=${authStore.token.value}&expirationTime=${authStore.token.expiration}` : '')">
+                  <ion-button color="medium" :href="'http://localhost:8101' + (authStore.isAuthenticated ? `/login?oms=${authStore.getOMS.startsWith('http') ? authStore.getOMS.includes('/api') ? authStore.getOMS : `${authStore.getOMS}/api/` : authStore.getOMS}&token=${authStore.token.value}&expirationTime=${authStore.token.expiration}` : '')">
                     <ion-icon slot="icon-only" :icon="codeWorkingOutline" />
                   </ion-button>
                   <ion-button color="medium" :href="scheme + app.handle + uatHandle + domain + (authStore.isAuthenticated ? `/login?oms=${authStore.getOMS.startsWith('http') ? authStore.getOMS.includes('/api') ? authStore.getOMS : `${authStore.getOMS}/api/` : authStore.getOMS}&token=${authStore.token.value}&expirationTime=${authStore.token.expiration}` : '')">

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -43,7 +43,7 @@
               <ion-card-header class="app-content">
                 <ion-card-title color="text-medium">{{ app.name }}</ion-card-title>
                 <ion-buttons class="app-links">
-                  <ion-button color="medium" :href="'http://localhost:8101' + (authStore.isAuthenticated ? `/login?oms=${authStore.getOMS.startsWith('http') ? authStore.getOMS.includes('/api') ? authStore.getOMS : `${authStore.getOMS}/api/` : authStore.getOMS}&token=${authStore.token.value}&expirationTime=${authStore.token.expiration}` : '')">
+                  <ion-button color="medium" :href="scheme + app.handle + devHandle + domain + (authStore.isAuthenticated ? `/login?oms=${authStore.getOMS.startsWith('http') ? authStore.getOMS.includes('/api') ? authStore.getOMS : `${authStore.getOMS}/api/` : authStore.getOMS}&token=${authStore.token.value}&expirationTime=${authStore.token.expiration}` : '')">
                     <ion-icon slot="icon-only" :icon="codeWorkingOutline" />
                   </ion-button>
                   <ion-button color="medium" :href="scheme + app.handle + uatHandle + domain + (authStore.isAuthenticated ? `/login?oms=${authStore.getOMS.startsWith('http') ? authStore.getOMS.includes('/api') ? authStore.getOMS : `${authStore.getOMS}/api/` : authStore.getOMS}&token=${authStore.token.value}&expirationTime=${authStore.token.expiration}` : '')">

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -55,7 +55,6 @@
 
 <script lang="ts">
 import {
-  alertController,
   IonButton,
   IonChip,
   IonContent,

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -116,9 +116,8 @@ export default defineComponent({
 
       // Run the basic login flow when oms and token both are found in query
       if (this.$route.query?.oms && this.$route.query?.token) {
-        // if a session is already active, present alert
-        if (this.authStore.isAuthenticated) {
-          await this.confirmActvSessnLoginOnRedrct(true)
+        if(this.authStore.getRedirectUrl) {
+          window.location.href = `${this.authStore.getRedirectUrl}?oms=${this.$route.query?.oms}&token=${this.$route.query?.token}`
         } else {
           await this.basicLogin()
           this.dismissLoader();
@@ -157,9 +156,13 @@ export default defineComponent({
         this.authStore.setRedirectUrl(this.$route.query.redirectUrl as string)
       }
 
-      // if a session is already active, present alert
-      if (this.authStore.isAuthenticated && this.$route.query?.redirectUrl) {
-        await this.confirmActvSessnLoginOnRedrct()
+      // if a session is already active, login directly in the app
+      if (this.authStore.isAuthenticated) {
+        if(this.authStore.getRedirectUrl) {
+          window.location.href = `${this.authStore.getRedirectUrl}?oms=${this.authStore.oms}&token=${this.authStore.token.value}&expirationTime=${this.authStore.token.expiration}`
+        } else {
+          this.router.push('/')
+        }
       }
 
       this.instanceUrl = this.authStore.oms;
@@ -284,42 +287,6 @@ export default defineComponent({
         console.error("error: ", error);
       }
       this.router.replace('/')
-    },
-    // Pass redirect as true when you want to remove all the url params when user clicks on login
-    async confirmActvSessnLoginOnRedrct(redirect = false) {
-      this.isConfirmingForActiveSession = true
-      const alert = await alertController
-        .create({
-          translucent: true,
-          backdropDismiss: false,
-          header: translate('Already active session'),
-          message: translate(`There is an already active session on for. Do you want to resume it, or would you prefer to log in again?`, { partyName: this.authStore.current.partyName, oms: this.authStore.getOMS }),
-          buttons: [{
-            text: translate('Resume'),
-            handler: () => {
-              if(this.authStore.getRedirectUrl) {
-                window.location.href = `${this.authStore.getRedirectUrl}?oms=${this.authStore.oms}&token=${this.authStore.token.value}&expirationTime=${this.authStore.token.expiration}`
-              } else {
-                this.router.push('/')
-              }
-              this.isConfirmingForActiveSession = false;
-            }
-          }, {
-            text: translate('Login'),
-            handler: async () => {
-              const redirectUrl = this.authStore.getRedirectUrl
-              await this.authStore.logout()
-              this.authStore.setRedirectUrl(redirectUrl)
-              this.isConfirmingForActiveSession = false;
-
-              if(redirect) {
-                this.basicLogin()
-                return;
-              }
-            }
-          }]
-        });
-      return alert.present();
     }
   },
   setup () {


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Related Issue https://github.com/hotwax/user-management/issues/181

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Previously when using different credentials to login into the app displays a toast to choose which instance to login breaks the flow when redirection across apps, so removed the logic to display the toast and login into the app with the incoming credentials.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to add changelog entry


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/job-manager#contribution-guideline)