### PR TITLE
Improved: Added a common toast message for Blocked/Disabled User Access Attempt(#103)

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -12,7 +12,7 @@
   "Please fill in the user details": "Please fill in the user details",
   "Processing": "Processing",
   "Something went wrong while login. Please contact administrator.": "Something went wrong while login. Please contact administrator.",
-  "Sorry, your username or password is incorrect. Please try again.": "Sorry, your username or password is incorrect. Please try again.",
+  "Sorry, either your login details are incorrect, or your account has been disabled or blocked. Please try again or contact administrator.": "Sorry, either your login details are incorrect, or your account has been disabled or blocked. Please try again or contact administrator.",
   "This application is not enabled for your account": "This application is not enabled for your account",
   "Username": "Username"
 }

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -47,7 +47,7 @@ export const useAuthStore = defineStore('authStore', {
       try {
         const resp = await UserService.login(username, password);
         if (hasError(resp)) {
-          showToast(translate('Sorry, your username or password is incorrect. Please try again.'));
+          showToast(translate('Sorry, either your login details are incorrect, or your account has been disabled or blocked. Please try again or contact administrator.'));
           console.error("error", resp.data._ERROR_MESSAGE_);
           return Promise.reject(new Error(resp.data._ERROR_MESSAGE_));
         }


### PR DESCRIPTION

### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#103 

### Short Description and Why It's Useful
- Added a common toast message for when a blocked or disabled user attempts to log in.
- This toast will also display when the user has incorrect login credentials.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/launchpad#contribution-guideline)