### PR TITLE
Improved: icons shown in user profile items and removed click event from icon (#91)

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -16,18 +16,14 @@
               <ion-label class="ion-text-nowrap">
                 <h2>{{ authStore.current?.partyName ? authStore.current?.partyName : authStore.current.userLoginId }}</h2>
               </ion-label>
-              <ion-button fill="clear" slot="end" @click="openUserActionsPopover($event)">
-                <ion-icon color="medium" slot="icon-only" :icon="chevronForwardOutline" />
-              </ion-button>
+              <ion-icon slot="end" :icon="chevronForwardOutline" class="ion-margin-start" />
             </ion-item>
             <ion-item lines="none" button @click="goToOms(authStore.token.value, authStore.getOMS)">
               <ion-icon slot="start" :icon="hardwareChipOutline"/>
               <ion-label>
                 <h2>{{ authStore.getOMS }}</h2>
               </ion-label>
-              <ion-button fill="clear">
-                <ion-icon color="medium" slot="icon-only" :icon="openOutline" />
-              </ion-button>
+              <ion-icon slot="end" :icon="openOutline" class="ion-margin-start" />
             </ion-item>
           </ion-list>
         </ion-card>


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#91

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Shown icons directly instead of showing them in ion-button inside of user-profile items.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/launchpad#contribution-guideline)