### PR TITLE
Implemented: added user permissions in state and updated Home view to conditionally display OMS card. (#132)

### DIFF
--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -40,8 +40,43 @@ const checkLoginOptions = async (): Promise<any> => {
   });
 }
 
+const getUserPermissions = async (token: any): Promise<any> => {
+  const authStore = useAuthStore()
+  const baseURL = authStore.getBaseUrl
+  let userPermissions = [] as any;
+  const payload = {
+    "viewIndex": 0,
+    "viewSize": 200,
+    "permissionIds": [
+      "COMMERCEUSER_VIEW",
+    ]
+  }
+
+  try {
+    const resp = await client({
+      url: "getPermissions",
+      method: "post",
+      baseURL,
+      data: payload,
+      headers: {
+        Authorization:  'Bearer ' + token,
+        'Content-Type': 'application/json'
+      },
+    });
+    
+    if (resp.status === 200 && resp.data.docs?.length && !hasError(resp)) {
+      userPermissions = resp.data.docs.map((permission: any) => permission.permissionId);
+    }
+
+    return userPermissions;
+  } catch(error: any) {
+    return Promise.reject(error)
+  }
+}
+
 export const UserService = {
   getUserProfile,
   checkLoginOptions,
-  login
+  login,
+  getUserPermissions
 }

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -15,7 +15,8 @@ export const useAuthStore = defineStore('authStore', {
       expiration: undefined
     },
     redirectUrl: '',
-    maargOms: ''
+    maargOms: '',
+    permissions: [] as string[]
   }),
   getters: {
     isAuthenticated: (state) => {
@@ -33,7 +34,8 @@ export const useAuthStore = defineStore('authStore', {
       return baseURL.startsWith('http') ? baseURL.includes('/api') ? baseURL : `${baseURL}/api/` : `https://${baseURL}.hotwax.io/api/`
     },
     getRedirectUrl: (state) => state.redirectUrl,
-    getMaargOms: (state) => state.maargOms
+    getMaargOms: (state) => state.maargOms,
+    getUserPermissions: (state) => state.permissions
   },
   actions: {
     setOMS(oms: string) {
@@ -58,6 +60,7 @@ export const useAuthStore = defineStore('authStore', {
         }
 
         this.current = await UserService.getUserProfile(this.token.value);
+        await this.setUserPermissions();
         updateToken(this.token.value)
         // Handling case for warnings like password may expire in few days
         if (resp.data._EVENT_MESSAGE_ && resp.data._EVENT_MESSAGE_.startsWith("Alert:")) {
@@ -145,7 +148,16 @@ export const useAuthStore = defineStore('authStore', {
     },
     async setMaargInstance(url: string) {
       this.maargOms = url
-    }
+    },
+    async setUserPermissions() {
+      try {
+        this.permissions = await UserService.getUserPermissions(this.token.value);
+      } catch (error: any) {
+        showToast(translate('Something went wrong while login. Please contact administrator.'));
+        console.error("error: ", error);
+        return Promise.reject(new Error(error))
+      }
+    },
   },
   persist: true
 })

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -9,7 +9,7 @@
         
         <ion-card v-if="authStore.isAuthenticated">
           <ion-list>
-            <ion-item lines="full" button @click="openUserActionsPopover($event)">
+            <ion-item :lines="isOmsAllowed ? 'full' : 'none'" button @click="openUserActionsPopover($event)">
               <ion-avatar slot="start">
                 <Image :src="authStore.current?.partyImageUrl" />
               </ion-avatar>
@@ -18,7 +18,7 @@
               </ion-label>
               <ion-icon slot="end" :icon="chevronForwardOutline" class="ion-margin-start" />
             </ion-item>
-            <ion-item lines="none" button @click="goToOms(authStore.token.value, authStore.getOMS)">
+             <ion-item v-if="isOmsAllowed" lines="none" button @click="goToOms(authStore.token.value, authStore.getOMS)">
               <ion-icon slot="start" :icon="hardwareChipOutline"/>
               <ion-label>
                 <h2>{{ authStore.getOMS }}</h2>
@@ -81,7 +81,7 @@ import {
   IonPage,
   popoverController
 } from '@ionic/vue';
-import { defineComponent, ref } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
 import {
   chevronForwardOutline,
   codeWorkingOutline,
@@ -159,6 +159,10 @@ export default defineComponent({
   setup() {
     const authStore = useAuthStore();
     const router = useRouter();
+
+    const isOmsAllowed = computed(() => {
+    return authStore.permissions.includes('COMMERCEUSER_VIEW');
+    });
 
     const appInfo = [{
       handle: 'bopis',
@@ -261,7 +265,8 @@ export default defineComponent({
       scheme,
       shieldHalfOutline,
       translate,
-      uatHandle
+      uatHandle,
+      isOmsAllowed
     }
   }
 });


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#132 

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
- introduced  a new state variable `permissions` that stores all available permissions to user.
- it consumes `api/getPermissions` api with user's token, we need to pass array of permissions we want to check against user's permissions.  
- if permissions in request params were on user, then response there are same permissions else not.
- created a service in `UserServices.ts` named `getUserPermissions(token)` that need token and as of now we are passing permissions to be checked statically, this can be made dynamic or other test permissions can be added in future.
- created state variable, getter and actions to set state.
- in component `Home.vue` consumed it using `authStore.permissions` and check for `COMMERCEUSER_VIEW` or test permission array item, if found we use isOmsAllowed to conditionally render ion-item containing oms url.
- also the same variable `isOmsAllowed` is used to conditionally render lines in first ion-item as ui was not looking good with single item and a bottom line.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->
[Screencast from 06-03-25 03:11:45 PM IST.webm](https://github.com/user-attachments/assets/e43c9bc8-3e8d-4ef5-9326-e8452e915fd2)


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/launchpad#contribution-guideline)